### PR TITLE
[Docker] - MultiStage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
+FROM maven:3.5-alpine as build
+COPY ./ ./
+RUN mvn clean
+RUN mvn install -DskipTests
+
+
 FROM openjdk:8-jre-alpine
 WORKDIR /root/sttDB-server
-
-ADD ./target/transcriptoma.db-*.jar ./app.jar
-
 ENV FILES_DIR /root/server-files
-
 EXPOSE 8080
+
+COPY --from=build ./target/transcriptoma.db-*.jar ./app.jar
 CMD java -Dserver.port=8080 -Dspring.profiles.active=production -jar app.jar


### PR DESCRIPTION
Aixi no us fara falta compilar localment, la imatge ja compile el codi font, transmet el resultat a la imatge final, i us quede del mateix tamany que lo que teniau. Lo unic es que fer `docker build` tardara mes.